### PR TITLE
UPDATE DirectoryProcessor set flag to allow a Collection Inventory to overwrite an existing product

### DIFF
--- a/src/main/java/gov/nasa/pds/crawler/proc/DirectoryProcessor.java
+++ b/src/main/java/gov/nasa/pds/crawler/proc/DirectoryProcessor.java
@@ -186,6 +186,12 @@ public class DirectoryProcessor
         // Collection label
         if(info instanceof PdsCollectionInfo)
         {
+            // Allow a Collection Inventory to overwrite the same ID added as a
+            // result of a situation where Harvest Service consumed a FileBatch, which includes the ID
+            // of Collection Inventory, before processing the CollectionInventory.
+            // Refer to https://github.com/NASA-PDS/registry-harvest-service/issues/25
+            dirMsg.overwrite = true;
+
             publishCollectionInventory(dirMsg, path, (PdsCollectionInfo)info);
         }
         


### PR DESCRIPTION

## 🗒️ Summary
In `registry-crawler-service`, the collection inventory files are submitted to `registry-harvest-service` as a `CollectionInventoryMessage` through RabbitMQ.

The same collection inventory files can be also submitted to `registry-harvest-service` as part of a batch as a `ProductMessage` through RabbitMQ.

When `registry-harvest-service`, receives the `CollectionInventoryMessage` before the `ProductMessage` batch, then it works as expected (uncertain, depending on the RabbitMQ queue message delivery time). 

However, if the `ProductMessage` batch (which includes the label of the collection inventory file) is received before the `CollectionInventoryMessage`, then the `registry-harvest-service` sees it as an already existing product and fails to process the `CollectionInventory`.

To resolve this, a change was made in this pull request. However, it is required to thoroughly review this before merging the change.


## ⚙️ Test Data and/or Report

The following image shows a comparison done to check is this change has any impact on the products loaded to Elasticsearch/ Opensearch (before and after the change). No change detected except data time and package_id changes.

<img width="1745" alt="Screen Shot 2022-09-08 at 1 01 24 AM" src="https://user-images.githubusercontent.com/94033485/189081688-60118a1e-216c-43ce-965f-784a3cbbe952.png">


## ♻️ Related Issues
Refer to issue NASA-PDS/registry-harvest-service#25
